### PR TITLE
Fixing the issue of not being able to send Logs to Otel Collector wit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ $ docker compose build
 $ docker compose up
 ```
 
-そのうえで、`src\WebApi\WebApi.csproj` を**ローカルホストで動かします。**
-動かし方は `dotnet run` でも Visual Studio でも Rider でも OK。
+~~そのうえで、`src\WebApi\WebApi.csproj` を**ローカルホストで動かします。**~~
+~~動かし方は `dotnet run` でも Visual Studio でも Rider でも OK。~~
 
-```
-$ dotnet run --project src\WebApi\WebApi.csproj --launch-profile https
-```
+~~$ dotnet run --project src\WebApi\WebApi.csproj --launch-profile https~~
 
 立ち上がった `WebApi.csproj` を雑に叩きまくる。
 
@@ -40,5 +38,5 @@ $ dotnet run --project src\WebApi\WebApi.csproj --launch-profile https
 
 ## 既知の問題
 
-`WebApi.csproj` を docker compose 内で動かしテレメトリデータを collector に送信する事は可能なのだが、何故かログの signal だけ collector が正常に処理してくれないので(collector が log の signal を backend に送信しない)。docker を使わずに普通に `WebApi.csproj` を動かし、localhost で collector につなげるとログも正常に処理される。
-実際 docker compose 内で動かしている `GrpcService.csproj` からはメトリクスとトレースは collector から各 backend に送信されているが、ログだけが送信されない。
+~~`WebApi.csproj` を docker compose 内で動かしテレメトリデータを collector に送信する事は可能なのだが、何故かログの signal だけ collector が正常に処理してくれないので(collector が log の signal を backend に送信しない)。docker を使わずに普通に `WebApi.csproj` を動かし、localhost で collector につなげるとログも正常に処理される。~~
+~~実際 docker compose 内で動かしている `GrpcService.csproj` からはメトリクスとトレースは collector から各 backend に送信されているが、ログだけが送信されない。~~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,20 @@
 version: '3.4'
 
 services:
-  # webapi:
-  #   image: ${DOCKER_REGISTRY-}webapi
-  #   build:
-  #     context: .
-  #     dockerfile: src/WebApi/Dockerfile
-  #   depends_on:
-  #     - otel-collector
+  webapi:
+    image: ${DOCKER_REGISTRY-}webapi
+    build:
+      context: .
+      dockerfile: src/WebApi/Dockerfile
+    ports:
+      - "5149:5149"
+      - "7237:7237"
+    environment:
+      - ASPNETCORE_HTTP_PORTS=5149
+      - ASPNETCORE_HTTPS_PORTS=7237
+      - ASPNETCORE_ENVIRONMENT=Development
+    depends_on:
+      - otel-collector
       
   grpcservice:
     image: ${DOCKER_REGISTRY-}grpcservice
@@ -21,7 +28,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.90.1
+    image: otel/opentelemetry-collector-contrib:0.92.0
     restart: always
     command: ["--config=/etc/otel-collector.yml"]
     volumes:

--- a/src/GrpcService/Program.cs
+++ b/src/GrpcService/Program.cs
@@ -38,7 +38,10 @@ builder.Logging
                 serviceInstanceId: instanceId
             ));
 
-        options.AddOtlpExporter();
+        options.AddOtlpExporter(op =>
+        {
+            op.Endpoint = new Uri("http://otel-collector:4317");
+        });
     });
 
 builder.Services.AddOpenTelemetry()

--- a/src/WebApi/Dockerfile
+++ b/src/WebApi/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 8080
@@ -22,4 +22,5 @@ RUN dotnet publish "./WebApi.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+RUN dotnet dev-certs https
 ENTRYPOINT ["dotnet", "WebApi.dll"]

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -33,7 +33,7 @@ builder.Services.AddSignalR(options =>
 builder.Services
     .AddGrpcClient<Greeter.GreeterClient>(options =>
     {
-        options.Address = new Uri("http://localhost:8080");
+        options.Address = new Uri("http://grpcservice:8080");
     });
 
 builder.Services.AddSingleton<IMessageRepository, MessageRepository>();
@@ -59,7 +59,10 @@ builder.Logging
                 serviceInstanceId: instanceId
             ));
 
-        options.AddOtlpExporter();
+        options.AddOtlpExporter(op =>
+        {
+            op.Endpoint = new Uri("http://otel-collector:4317");
+        });
     });
 
 builder.Services.AddOpenTelemetry()
@@ -90,8 +93,7 @@ builder.Services.AddOpenTelemetry()
             .AddOtlpExporter();
     });
 
-
-builder.Services.AddNpgsqlDataSource("Host=localhost;Port=5432;Username=postgres;Password=postgres;");
+builder.Services.AddNpgsqlDataSource("Host=postgres;Port=5432;Username=postgres;Password=postgres;");
 
 var app = builder.Build();
 

--- a/src/WebApi/appsettings.json
+++ b/src/WebApi/appsettings.json
@@ -8,5 +8,5 @@
     },
     "AllowedHosts": "*",
     "ASPNETCORE_ENVIRONMENT": "Development",
-    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4317"
 }


### PR DESCRIPTION
#1 

修正した内容をプルリクします。よろしくお願いします。

```log
opentelemetry-dotnet-example-webapi-1          |       StatusCode: 200
opentelemetry-dotnet-example-webapi-1          | info: Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware[8]
opentelemetry-dotnet-example-webapi-1          |       => SpanId:af25ec7f933c4dad, TraceId:f31725d2e485cc572266907e7dcd3986, ParentId:0000000000000000 => ConnectionId:0HN0IDP830PKU => RequestPath:/WeatherForecast RequestId:0HN0IDP830PKU:00000011
opentelemetry-dotnet-example-webapi-1          |       Duration: 1869.2417ms
opentelemetry-dotnet-example-otel-collector-1  | 2024-01-11T06:27:10.507Z       info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 3}
opentelemetry-dotnet-example-otel-collector-1  | 2024-01-11T06:27:11.937Z       info    LogsExporter    {"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 4}
opentelemetry-dotnet-example-otel-collector-1  | 2024-01-11T06:27:12.882Z       info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 3}
```